### PR TITLE
feat: add filter warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -225,13 +225,13 @@
       "requires": {
         "@types/events": "1.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "9.4.6"
+        "@types/node": "9.4.7"
       }
     },
     "@types/jest": {
-      "version": "22.1.4",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-22.1.4.tgz",
-      "integrity": "sha512-X10GI+5Ys+iAPooC3lbsemjjydjD2Y4o481oU2AnqXi26Txas5hppqTYqncKzWeU6XXxH2trr5LauhwkiWZdxA==",
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-22.2.0.tgz",
+      "integrity": "sha512-5DeGD46Goq6+GtEEB57hQzC/BbuEbEj0fUCDm7a5Fm9ZYLL3odPh1kYn9yMtQe1rKNg/BcVmadroBCyih6thtw==",
       "dev": true
     },
     "@types/minimatch": {
@@ -241,10 +241,19 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.4.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
-      "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ==",
+      "version": "9.4.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.7.tgz",
+      "integrity": "sha512-4Ba90mWNx8ddbafuyGGwjkZMigi+AWfYLSDCpovwsE63ia8w93r3oJ8PIAQc3y8U+XHcnMOHPIzNe3o438Ywcw==",
       "dev": true
+    },
+    "@unional/logging": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@unional/logging/-/logging-0.4.0.tgz",
+      "integrity": "sha512-MsmQqqcsl5QEkS7QNOXCgkgo+r5fcplNpp2bTt34wv6KGTpjZ7zHbupx0fDv4vmgaXke4KD05lFWpBrzb7FZDg==",
+      "requires": {
+        "aurelia-logging": "1.4.0",
+        "global-store": "0.7.3"
+      }
     },
     "JSONStream": {
       "version": "1.3.2",
@@ -581,6 +590,29 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
+    },
+    "aurelia-logging": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/aurelia-logging/-/aurelia-logging-1.4.0.tgz",
+      "integrity": "sha1-BPt6p0AVWT96FbIlvuuge30U3NU="
+    },
+    "aurelia-logging-color": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/aurelia-logging-color/-/aurelia-logging-color-0.5.15.tgz",
+      "integrity": "sha512-3QAsKsxMz/OOpAM5qm+oQ7EBZKiSFE7lMw47pLPoGcnoFZCxic3y9n7GY2irDLXYiHOKpF5EvoqQYnWiNq7mzA==",
+      "requires": {
+        "color-map": "0.5.11"
+      }
+    },
+    "aurelia-logging-memory": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/aurelia-logging-memory/-/aurelia-logging-memory-0.3.0.tgz",
+      "integrity": "sha512-b9K1XsvAPYG0hdltjXPN/wEM6fx8zkOcEqujt7j+fjh5xLwOOU6xB7LIOY4nAh/HGhe7qD6VNVvcwN2+2SyDKQ==",
+      "dev": true,
+      "requires": {
+        "coveralls": "3.0.0",
+        "upper-case": "1.1.3"
+      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -1196,6 +1228,11 @@
         "color-name": "1.1.3"
       }
     },
+    "color-map": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/color-map/-/color-map-0.5.11.tgz",
+      "integrity": "sha512-auh6qowlRETkIfe/Ch126D43EcC+b3c7RSP+7hOZ1HUWp5wHmT7g9MSq3+RwDNlNlJURhBb7vqamzLUxHonoTQ=="
+    },
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
@@ -1369,6 +1406,27 @@
             "error-ex": "1.3.1",
             "json-parse-better-errors": "1.0.1"
           }
+        }
+      }
+    },
+    "coveralls": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.0.tgz",
+      "integrity": "sha512-ZppXR9y5PraUOrf/DzHJY6gzNUhXYE3b9D43xEXs4QYZ7/Oe0Gy0CS+IPKWFfvQFXB3RG9QduaQUFehzSpGAFw==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "3.10.0",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.7",
+        "minimist": "1.2.0",
+        "request": "2.83.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
         }
       }
     },
@@ -3685,6 +3743,11 @@
         "find-index": "0.1.1"
       }
     },
+    "global-store": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/global-store/-/global-store-0.7.3.tgz",
+      "integrity": "sha512-gbIeTHUwFZykgL2m72V4oy1gz3UIQ9bMCK4CSlhBhikjE10XUM8sRWO2gn0HzfyKX1M05uQmzIq9PZxo6bOcOg=="
+    },
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
@@ -4903,6 +4966,12 @@
         "invert-kv": "1.0.0"
       }
     },
+    "lcov-parse": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+      "dev": true
+    },
     "left-pad": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
@@ -4975,6 +5044,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
+      "dev": true
+    },
+    "log-driver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
     "longest": {
@@ -7425,6 +7500,12 @@
       "requires": {
         "lodash.merge": "4.6.1"
       }
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+      "dev": true
     },
     "url-join": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -49,9 +49,10 @@
   },
   "devDependencies": {
     "@types/glob": "^5.0.35",
-    "@types/jest": "^22.1.4",
-    "@types/node": "^9.4.6",
+    "@types/jest": "^22.2.0",
+    "@types/node": "^9.4.7",
     "assertron": "^4.1.0",
+    "aurelia-logging-memory": "^0.3.0",
     "dependency-check": "^3.1.0",
     "eslint": "^4.18.2",
     "eslint-plugin-unional": "^1.0.0",
@@ -67,6 +68,8 @@
   },
   "dependencies": {
     "@types/diff": "^3.2.2",
+    "@unional/logging": "^0.4.0",
+    "aurelia-logging-color": "^0.5.15",
     "chalk": "^2.3.2",
     "cp-file": "^5.0.0",
     "diff": "^3.5.0",

--- a/src/baseline.filter.spec.ts
+++ b/src/baseline.filter.spec.ts
@@ -1,0 +1,92 @@
+import { clearAppenders, setLevel, logLevel, addAppender } from '@unional/logging'
+import { MemoryAppender } from 'aurelia-logging-memory'
+import assert from 'assert'
+import { AssertOrder } from 'assertron'
+
+import { baseline } from '.'
+
+beforeEach(() => {
+  setLevel(logLevel.none)
+})
+
+afterEach(() => {
+  clearAppenders()
+  setLevel(logLevel.none)
+})
+
+test('filter cases using RegExp', () => {
+  const o = new AssertOrder()
+  baseline({
+    basePath: 'fixtures/file-cases',
+    filter: /file1/
+  }, ({ caseName }) => {
+    assert.equal(caseName, 'file1.txt')
+    o.once(1)
+  })
+
+  o.end()
+})
+
+test('filter cases using wildcards', () => {
+  const o = new AssertOrder()
+  baseline({
+    basePath: 'fixtures/file-cases',
+    filter: '*1.*'
+  }, ({ caseName }) => {
+    assert.equal(caseName, 'file1.txt')
+    o.once(1)
+  })
+
+  o.end()
+})
+
+test('filter with negate keeps others', () => {
+  const o = new AssertOrder()
+  baseline({
+    basePath: 'fixtures/file-cases',
+    filter: '!file1.txt'
+  }, ({ caseName }) => {
+    assert.equal(caseName, 'file2.txt')
+    o.once(1)
+  })
+  o.end()
+})
+
+
+test('log filtered case', () => {
+  setLevel(logLevel.warn)
+  const mem = new MemoryAppender()
+  addAppender(mem)
+
+  const o = new AssertOrder()
+  baseline({
+    basePath: 'fixtures/file-cases',
+    filter: '!file1.txt'
+  }, ({ caseName }) => {
+    assert.equal(caseName, 'file2.txt')
+    o.once(1)
+  })
+
+  assert.equal(mem.logs.length, 1)
+  o.end()
+})
+
+
+test('suppressFilterWarning option will skip log filtered case', () => {
+  setLevel(logLevel.warn)
+  const mem = new MemoryAppender()
+  addAppender(mem)
+
+  const o = new AssertOrder()
+  baseline({
+    basePath: 'fixtures/file-cases',
+    filter: '!file1.txt',
+    suppressFilterWarning: true
+  }, ({ caseName }) => {
+    assert.equal(caseName, 'file2.txt')
+    o.once(1)
+  })
+
+  assert.equal(mem.logs.length, 0)
+  o.end()
+})

--- a/src/baseline.spec.ts
+++ b/src/baseline.spec.ts
@@ -61,44 +61,6 @@ test('invoke callback for each folder', () => {
   pathsEqual(baselineFolders, ['fixtures/dir-cases/baselines/case1', 'fixtures/dir-cases/baselines/case2'])
 })
 
-test('filter cases using RegExp', () => {
-  const o = new AssertOrder()
-  baseline({
-    basePath: 'fixtures/file-cases',
-    filter: /file1/
-  }, ({ caseName }) => {
-    assert.equal(caseName, 'file1.txt')
-    o.once(1)
-  })
-
-  o.end()
-})
-
-test('filter cases using wildcards', () => {
-  const o = new AssertOrder()
-  baseline({
-    basePath: 'fixtures/file-cases',
-    filter: '*1.*'
-  }, ({ caseName }) => {
-    assert.equal(caseName, 'file1.txt')
-    o.once(1)
-  })
-
-  o.end()
-})
-
-test('filter with negate keeps others', () => {
-  const o = new AssertOrder()
-  baseline({
-    basePath: 'fixtures/file-cases',
-    filter: '!file1.txt'
-  }, ({ caseName }) => {
-    assert.equal(caseName, 'file2.txt')
-    o.once(1)
-  })
-  o.end()
-})
-
 test(`'results' folder is created for file cases`, () => {
   ensureFolderNotExist('fixtures/no-file-results/results')
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,9 @@
+import { getLogger, Logger, setDefaultAppender, setLevel, logLevel } from '@unional/logging'
+import { ColorAppender } from 'aurelia-logging-color'
+
+const log: Logger = getLogger('fixture')
+
+setLevel(logLevel.warn)
+setDefaultAppender(new ColorAppender())
+
+export { log }


### PR DESCRIPTION
When a case is filtered, by default it will log a warning message.

This is added to avoid accidentally leaving the filter in the test.

You can suppress this warning using the `suppressFilterWarning` options..

But normally you should not do so.