### PR TITLE
feat!: upgrade chalk

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@types/diff-match-patch": "^1.0.32",
-    "chalk": "^4.1.2",
+    "chalk": "^5.0.1",
     "cp-file": "^9.1.0",
     "diff-match-patch": "^1.0.5",
     "diff-match-patch-line-and-word": "^0.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2830,7 +2830,7 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^5.0.0:
+chalk@^5.0.0, chalk@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.0.1.tgz#ca57d71e82bb534a296df63bbacc4a1c22b2a4b6"
   integrity sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==


### PR DESCRIPTION
BREAKING CHANGE: upgrade chalk

`chalk@5` is published as ESM, and that breaks `jest`.

Need to add this to `jest.config.js`:

```
{
  moduleNameMapper: {
    '#(.*)': '<rootDir>/node_modules/$1'
  },
  transformIgnorePatterns: [
    'node_modules/(?!(chalk)/)'
  ]
}
```