### PR TITLE
fix: avoid creating baselines folder

### DIFF
--- a/fixtures/custom-saved/actuals/case-1.txt/case-1.txt
+++ b/fixtures/custom-saved/actuals/case-1.txt/case-1.txt
@@ -1,0 +1,1 @@
+some value

--- a/fixtures/custom-saved/expects/case-1.txt/case-1.txt
+++ b/fixtures/custom-saved/expects/case-1.txt/case-1.txt
@@ -1,0 +1,1 @@
+some value

--- a/ts/baseline.ts
+++ b/ts/baseline.ts
@@ -110,7 +110,6 @@ export const baseline = Object.assign(
     if (cases.length === 0) throw new NoCaseFound(casesFolder)
 
     ensureFolderExist(resultsFolder)
-    ensureFolderExist(baselinesFolder)
 
     cases.forEach(caseName => {
       const context = createContext(caseName, casesFolder, baselinesFolder, resultsFolder, options)

--- a/ts/copyToBaseline.ts
+++ b/ts/copyToBaseline.ts
@@ -1,6 +1,7 @@
 import { copyFile } from 'cp-file'
 import glob from 'glob'
 import path from 'path'
+import { ensureFolderExist } from './fsUtils.js'
 
 export interface CopyToBaseline {
   (wildcardOrRegExp?: string): Promise<void>,
@@ -9,6 +10,7 @@ export interface CopyToBaseline {
 export function createCopyToBaselineFunction(baselineFolder: string, resultFolder: string) {
   return Object.assign(
     function copyToBaseline(wildcardOrRegExp = '*') {
+      ensureFolderExist(baselineFolder)
       return new Promise<string[]>(a => {
         glob(wildcardOrRegExp, { cwd: resultFolder }, (_err, files) => {
           a(files)

--- a/ts/match.ts
+++ b/ts/match.ts
@@ -17,10 +17,15 @@ export function createMatchFunction(baselinePath: string, resultPath: string, op
       removeUnchangedFiles(filesBeforeTest, filesAfterTest)
     }
 
+    const resultTarget = path.join(resultPath, target)
+    if (!fs.existsSync(baselinePath)) {
+      throw new ExtraResultFile(resultTarget, '', options)
+    }
+
     return compare(
       match,
       path.join(baselinePath, target),
-      path.join(resultPath, target),
+      resultTarget,
       options
     )
   }


### PR DESCRIPTION
This make copying results to baselines manually easier to do